### PR TITLE
Fix images not loading on public homepage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,7 @@ export default async function RootLayout({
         <nav className="relative border-b border-gray-200 bg-white">
           <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
             <Link href="/">
-              <Image src="/logo.svg" alt="AskThem" width={135} height={30} priority />
+              <Image src="/logo.svg" alt="AskThem" width={135} height={30} priority unoptimized />
             </Link>
 
             {/* Desktop nav */}
@@ -155,7 +155,7 @@ export default async function RootLayout({
         {/* Footer */}
         <footer className="border-t border-gray-200 bg-white px-4 py-6">
           <div className="mx-auto flex max-w-5xl items-center justify-between text-sm text-gray-500">
-            <Image src="/logo.svg" alt="AskThem" width={100} height={22} />
+            <Image src="/logo.svg" alt="AskThem" width={100} height={22} unoptimized />
             <div className="flex items-center gap-4">
               <Link href="/about" className="text-gray-500 hover:text-indigo-600">
                 About

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -209,6 +209,7 @@ export default function PreviewPage() {
               width={1200}
               height={800}
               className="h-auto w-full"
+              unoptimized
             />
           </div>
         </section>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,8 +13,12 @@ export function middleware(req: NextRequest) {
   if (sitePassword) {
     const authCookie = req.cookies.get("site-auth")?.value;
     if (authCookie !== sitePassword) {
-      // Allow the public preview homepage and Auth.js routes through
-      if (pathname === "/" || pathname.startsWith("/api/auth")) {
+      // Allow the public preview homepage, static assets, and Auth.js routes through
+      if (
+        pathname === "/" ||
+        pathname.startsWith("/api/auth") ||
+        /\.(png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|eot|css|js)$/.test(pathname)
+      ) {
         return NextResponse.next();
       }
       // If this is the password form submission, check the password


### PR DESCRIPTION
## Summary
- Exempt static assets (.png, .svg, .jpg, etc.) from the middleware password gate so unauthenticated visitors can load images
- Add `unoptimized` to homepage infographic and layout logo SVGs to serve directly from /public instead of /_next/image
- Also includes: preview page as homepage, old homepage moved to /home, period restore

## Test plan
- Visit https://www.askthem.us/ without entering site password
- Verify the AI infographic image and logo SVGs load correctly

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao