### PR TITLE
Add contact info to splash and contact pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -18,7 +18,14 @@ export default function ContactPage() {
         <section className="mb-10">
           <h2 className="mb-4 text-xl font-semibold text-gray-900">Email</h2>
           <p className="text-gray-700">
-            Email us: <span className="text-gray-400">[soon]</span>
+            <a href="mailto:davidrussellmoore@gmail.com" className="text-indigo-600 hover:text-indigo-800">davidrussellmoore@gmail.com</a>
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Signal</h2>
+          <p className="text-gray-700">
+            davidrussellmoore.52
           </p>
         </section>
 
@@ -29,7 +36,7 @@ export default function ContactPage() {
           <ul className="space-y-2 text-gray-700">
             <li>
               <a
-                href="https://bsky.app"
+                href="https://bsky.app/profile/davidrussellmoore.bsky.social"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-indigo-600 hover:text-indigo-800"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,8 +213,12 @@ export default function PreviewPage() {
             <a href="https://actionnetwork.org/fundraising/donate-to-askthem-free-open-source/" className="text-indigo-600 hover:text-indigo-800" target="_blank" rel="noopener noreferrer">Action Network</a>
           </p>
           <p className="text-sm text-gray-500">
-            Contact:{" "}
-            <a href="https://bsky.app/profile/davidrussellmoore.bsky.social" className="text-indigo-600 hover:text-indigo-800" target="_blank" rel="noopener noreferrer">David Moore</a>
+            Contact: David Moore —{" "}
+            <a href="mailto:davidrussellmoore@gmail.com" className="text-indigo-600 hover:text-indigo-800">davidrussellmoore@gmail.com</a>
+            {" | "}
+            <a href="https://bsky.app/profile/davidrussellmoore.bsky.social" className="text-indigo-600 hover:text-indigo-800" target="_blank" rel="noopener noreferrer">Bluesky</a>
+            {" | "}
+            Signal: davidrussellmoore.52
           </p>
         </section>
       </div>


### PR DESCRIPTION
Add contact details to splash page and /contact:
- Email: davidrussellmoore@gmail.com
- Signal: davidrussellmoore.52
- Bluesky link updated to actual profile

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao