### PR TITLE
Add donate links and obfuscate email

### DIFF
--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -9,9 +9,10 @@ export const metadata: Metadata = {
 const channels = [
   {
     name: "OpenCollective",
+    href: "https://opencollective.com/dashboard/participatory-politics-fdn",
     description:
       "Contributions through OpenCollective are tax-deductible and fully transparent — every dollar in and out is public.",
-    cta: "Coming soon",
+    cta: "Donate on OpenCollective",
     icon: (
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-8 w-8 text-orange-600">
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A8.966 8.966 0 0 1 3 12c0-1.264.26-2.466.732-3.558" />
@@ -20,9 +21,10 @@ const channels = [
   },
   {
     name: "Action Network",
+    href: "https://actionnetwork.org/fundraising/donate-to-askthem-free-open-source/",
     description:
       "Make a one-time or recurring donation through Action Network. Your contribution helps us keep the platform free and accessible to every constituent.",
-    cta: "Coming soon",
+    cta: "Donate on Action Network",
     icon: (
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-8 w-8 text-orange-600">
         <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
@@ -31,9 +33,10 @@ const channels = [
   },
   {
     name: "Donor-Advised Fund (DAF)",
+    href: "https://participatorypolitics.org/",
     description:
       "If you have a donor-advised fund, you can recommend a grant to AskThem. Contact us for our EIN and mailing details.",
-    cta: "Coming soon",
+    cta: "Visit Participatory Politics Foundation",
     icon: (
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-8 w-8 text-orange-600">
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
@@ -42,9 +45,10 @@ const channels = [
   },
   {
     name: "PayPal",
+    href: "https://www.paypal.com/ncp/payment/WMGF8PW789G6Q",
     description:
       "Send a quick contribution via PayPal. No account required — just a credit or debit card.",
-    cta: "Coming soon",
+    cta: "Donate with PayPal",
     icon: (
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-8 w-8 text-orange-600">
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
@@ -76,9 +80,14 @@ export default function DonatePage() {
                 <div className="flex-1">
                   <h2 className="text-lg font-semibold text-gray-900">{ch.name}</h2>
                   <p className="mt-1 text-sm leading-relaxed text-gray-600">{ch.description}</p>
-                  <span className="mt-3 inline-block rounded-full bg-orange-100 px-3 py-1 text-xs font-medium text-orange-700">
-                    {ch.cta}
-                  </span>
+                  <a
+                    href={ch.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-3 inline-block rounded-full bg-orange-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-orange-700 transition-colors"
+                  >
+                    {ch.cta} &rarr;
+                  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Add live donate links on /donate page:
- OpenCollective → opencollective.com/dashboard/participatory-politics-fdn
- Action Network → actionnetwork.org fundraising page
- DAF → participatorypolitics.org
- PayPal → paypal.com payment link

Also includes email obfuscation from previous commit.

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao