### PR TITLE
Move Action Network form to contact, add dummy signup

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { ObfuscatedEmail } from "@/components/ObfuscatedEmail";
 
 export const metadata: Metadata = {
@@ -28,6 +29,26 @@ export default function ContactPage() {
           <p className="text-gray-700">
             davidrussellmoore.52
           </p>
+        </section>
+
+        {/* ── Action Network Signup ─────────────────────────────── */}
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Get Updates</h2>
+          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <link
+              href="https://actionnetwork.org/css/style-embed-v3.css"
+              rel="stylesheet"
+              type="text/css"
+            />
+            <Script
+              src="https://actionnetwork.org/widgets/v6/form/get-updates-from-askthem?format=js&source=widget"
+              strategy="afterInteractive"
+            />
+            <div
+              id="can-form-area-get-updates-from-askthem"
+              style={{ width: "100%" }}
+            />
+          </div>
         </section>
 
         <section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import Script from "next/script";
 import { ObfuscatedEmail } from "@/components/ObfuscatedEmail";
+import { DummyEmailSignup } from "@/components/DummyEmailSignup";
 
 export const metadata: Metadata = {
   title: "Preview - AskThem",
@@ -61,29 +61,23 @@ export default function PreviewPage() {
           AskThem
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-indigo-100">
-          A free questions-and-answers platform with elected officials. Created
-          in 2014, we&rsquo;re now seeking partners to launch a new version with
+          A free questions-and-answers platform with elected officials.
+          We&rsquo;re seeking partners to launch a new version with
           civic AI for moderated public dialogue.
         </p>
       </section>
 
       <div className="mx-auto max-w-4xl px-4 py-16">
-        {/* ── Action Network Signup ─────────────────────────────── */}
+        {/* ── Email Signup ──────────────────────────────────────── */}
         <section className="mb-20">
           <div className="mx-auto max-w-lg rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <link
-              href="https://actionnetwork.org/css/style-embed-v3.css"
-              rel="stylesheet"
-              type="text/css"
-            />
-            <Script
-              src="https://actionnetwork.org/widgets/v6/form/get-updates-from-askthem?format=js&source=widget"
-              strategy="afterInteractive"
-            />
-            <div
-              id="can-form-area-get-updates-from-askthem"
-              style={{ width: "100%" }}
-            />
+            <h2 className="mb-2 text-center text-lg font-bold text-gray-900">
+              Get Updates
+            </h2>
+            <p className="mb-4 text-center text-sm text-gray-600">
+              Sign up for news on our relaunch and ways to get involved.
+            </p>
+            <DummyEmailSignup />
           </div>
         </section>
 

--- a/src/components/DummyEmailSignup.tsx
+++ b/src/components/DummyEmailSignup.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+export function DummyEmailSignup() {
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (email) setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <p className="text-center text-sm font-medium text-emerald-700">
+        Thanks for signing up! We&rsquo;ll be in touch.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        type="email"
+        required
+        placeholder="your@email.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+      />
+      <button
+        type="submit"
+        className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
+      >
+        Sign Up
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
- Remove "Created in 2014" from hero text
- Replace Action Network embed on homepage with a dummy email signup form
- Move the Action Network form to /contact page

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao