### PR TITLE
Hide Action Network form chrome on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,15 @@ export default function PreviewPage() {
       <div className="mx-auto max-w-4xl px-4 py-16">
         {/* ── Action Network Signup ─────────────────────────────── */}
         <section className="mb-20">
-          <div className="mx-auto max-w-lg rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="an-minimal mx-auto max-w-lg rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <style>{`
+              .an-minimal #can-form-area-get-updates-from-askthem-2 h2,
+              .an-minimal #can-form-area-get-updates-from-askthem-2 h4,
+              .an-minimal .action_network_footer,
+              .an-minimal #can-form-area-get-updates-from-askthem-2 .action_sponsor {
+                display: none !important;
+              }
+            `}</style>
             <link
               href="https://actionnetwork.org/css/style-embed-v3.css"
               rel="stylesheet"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,10 +60,12 @@ export default function PreviewPage() {
         <h1 className="mx-auto max-w-3xl text-4xl font-bold leading-tight sm:text-5xl">
           AskThem
         </h1>
-        <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-indigo-100">
-          A free questions-and-answers platform with elected officials.
-          We&rsquo;re seeking partners to launch a new version with
-          civic AI for moderated public dialogue.
+        <p className="mx-auto mt-4 max-w-2xl text-xl font-semibold text-white">
+          Real Officials, Verified Voters
+        </p>
+        <p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-indigo-100">
+          Get real answers from elected officials and candidates about the most
+          important questions in your community.
         </p>
       </section>
 


### PR DESCRIPTION
Hide Action Network form chrome (title, "enter your email", sponsored-by, AN logo) via CSS, leaving just the email input and submit button.

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao