### PR TITLE
Hide Action Network sponsored-by and logo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,8 +76,11 @@ export default function PreviewPage() {
             <style>{`
               .an-minimal #can-form-area-get-updates-from-askthem-2 h2,
               .an-minimal #can-form-area-get-updates-from-askthem-2 h4,
-              .an-minimal .action_network_footer,
-              .an-minimal #can-form-area-get-updates-from-askthem-2 .action_sponsor {
+              .an-minimal #can-form-area-get-updates-from-askthem-2 #action_info,
+              .an-minimal #can-form-area-get-updates-from-askthem-2 #logo_wrap,
+              .an-minimal #can-form-area-get-updates-from-askthem-2 #d_sharing,
+              .an-minimal #can-form-area-get-updates-from-askthem-2 .action_sponsor,
+              .an-minimal .action_network_footer {
                 display: none !important;
               }
             `}</style>


### PR DESCRIPTION
Add CSS selectors to hide the remaining Action Network branding: `#logo_wrap` (AN logo), `#action_info` (sponsored-by line), `#d_sharing` (share buttons).

https://claude.ai/code/session_01JaU63cMnnqB5BojN7jsrao